### PR TITLE
feat: Add dynamic layout option for K2 comms

### DIFF
--- a/app/controllers/devise/displayqr_controller.rb
+++ b/app/controllers/devise/displayqr_controller.rb
@@ -71,7 +71,9 @@ class Devise::DisplayqrController < DeviseController
   def dynamic_layout
     if resource.is_a?(User)
       'application'
-    elsif resource.is_a?(SaasAdmin)
+    elsif defined?(Administrator) && resource.is_a?(Administrator)
+      'application'
+    elsif defined?(SaasAdmin) && resource.is_a?(SaasAdmin)
       'k2admin'
     end
   end


### PR DESCRIPTION
This pull request updates the `dynamic_layout` method in the `app/controllers/devise/displayqr_controller.rb` file to improve layout determination logic by adding checks for the existence of certain classes before using them.

### Updates to layout determination logic:

* [`app/controllers/devise/displayqr_controller.rb`](diffhunk://#diff-c1ec3dde9a828b06d0b9624a2d838bf0f279bb905eca8f315ee1a2d45ec0030dL74-R76): Modified the `dynamic_layout` method to include `defined?(Administrator)` and `defined?(SaasAdmin)` checks before determining the layout for `Administrator` and `SaasAdmin` resources. This ensures the method does not raise errors if these classes are not defined.